### PR TITLE
Update scripts to use Docopt instead of Argparse

### DIFF
--- a/src/get_datasets.py
+++ b/src/get_datasets.py
@@ -1,63 +1,28 @@
+"""
+Retrieve datasets from a URL, file of URLs, or GitHub directory URL
+
+Usage: get_datasets.py -i=<input> -o=<output> [-u] [-f] [-g] [-v]
+
+Options:
+-i <input>, --input <input>     Input URL
+-o <output>, --output <output>  The local output location to transfer the datasets
+[-u]                            (Default) Retrieve the input file from the given URL
+[-f]                            Retrieve the list of file URLs specified in the input file
+[-g]                            Retrieve the entire file contents of a github directory
+[-v]                            Report verbose output of dataset retrieval process
+"""
+import os
+import sys
+import json
+import urllib.request
+from docopt import docopt
+args = docopt(__doc__)
+
+
 def get_datasets():
-    """
-    Retrieve datasets from a URL, file of URLs, or GitHub directory URL
-
-    Parameters
-    ----------
-    -i/--input  : string
-        Input url path
-    -o/--output : string
-        The local output location to transfer the datasets
-
-    Options
-    -------
-    -u/--url        : boolean
-        (Default) Retrieve the input given as a file URL
-    -f/--file       : boolean
-        Retrieve the list of file URL specified in the input file
-    -g/--github_url : boolean
-        Retrieve the entire file contents of a github directory
-    -v/--verbose    : boolean
-        Report verbose output of dataset retrieval process
-
-    Examples
-    --------
-    python get_datasets.py -i \
-        https://raw.githubusercontent.com/rudeboybert/fivethirtyeight/master/data-raw/comic-characters/dc-wikia-data.csv \
-        -o ../data/raw -u -v
-
-    python get_datasets.py -i \
-        ../data/my_dataset_file_urls.txt \
-        -o ../data/raw -f -v
-
-    python get_datasets.py -i \
-        https://github.com/rudeboybert/fivethirtyeight/tree/master/data-raw/comic-characters \
-        -o ../data/raw -g -v
-    """
-    import os
-    import sys
-    import json
-    import urllib.request
-    import argparse
-
-    # Setup script argument parsing
-    ap = argparse.ArgumentParser()
-
-    ap.add_argument("-i", "--input", required=True, help="input url or file path")
-    ap.add_argument("-o", "--output", required=True, help="output path")
-    ap.add_argument("-u", "--url", required=False, action='store_true',
-        help="Read the input url from the input argument (Default) (Optional)")
-    ap.add_argument("-f", "--file", required=False, action='store_true',
-        help="Read the input urls from a the given input file (Optional)")
-    ap.add_argument("-g", "--git_directory", required=False, action='store_true',
-        help="Read the input url from the input files from a git directory (Optional)")
-    ap.add_argument("-v", "--verbose", required=False, action='store_true',
-        help="Print script output (Optional)")
-    args = vars(ap.parse_args())
-
-    input = args["input"]
-    output_path = args["output"]
-    verbose = args["verbose"]
+    input = args["--input"]
+    output_path = args["--output"]
+    verbose = args["-v"]
 
     assert input, "Empty input argument provided"
 
@@ -70,11 +35,11 @@ def get_datasets():
     if verbose: print(f"Running get_dataset with arguments: \n {args}")
 
     download_urls = []
-    if args['git_directory'] is True: 
+    if args['-g'] is True: 
         # If this is a github repo, construct GET api request to 
         # retrieve all repo directory datafiles
         github_api_url = "https://api.github.com/repos/"
-        repo_url = args["input"].split(os.path.sep)
+        repo_url = args["--input"].split(os.path.sep)
         # These magic numbers parse out the unnecessary github url branch info
         github_api_url = github_api_url + \
             (os.path.sep).join(repo_url[3:5] + ["contents"] + repo_url[7:])
@@ -90,7 +55,7 @@ def get_datasets():
         git_files = json.loads(response.decode('utf-8'))
         for file in git_files:
             download_urls.append(file["download_url"])
-    elif args['file'] is True:
+    elif args['-f'] is True:
         assert os.path.exists(input), "Input file is not valid"
         input_fh = open(input, "r")
         for line in input_fh:

--- a/src/preprocess_data.py
+++ b/src/preprocess_data.py
@@ -17,7 +17,6 @@ args = docopt(__doc__)
 
 def preprocess_data():
     # Setup script argument parsing
-    print(args)
     input_dir = args["--input"]
     output_filename = args["--output"]
     verbose = args["-v"]

--- a/src/preprocess_data.py
+++ b/src/preprocess_data.py
@@ -1,41 +1,26 @@
+"""
+Retrieve datasets from a URL, file of URLs, or GitHub directory URL
+
+Usage: preprocess_data.py -i=<input> -o=<output> [-v]
+
+Options:
+-i <input>, --input <input>     Local raw data csv file directory
+-o <output>, --output <output>  Local output filename and path for preprocessed csv
+[-v]                            Report verbose output of dataset retrieval process
+"""
+import os
+import glob
+import pandas as pd
+from docopt import docopt
+args = docopt(__doc__)
+
+
 def preprocess_data():
-    """
-    Clean the raw local csv files before processing
-
-    Parameters
-    ----------
-    -i/--input  : string
-        Local raw data csv file directory
-    -o/--output : string
-        Local output filename and path for preprocessed csv
-
-    Options
-    -v/--verbose    : boolean
-        Report verbose output of dataset retrieval process
-
-    Examples
-    --------
-    python preprocess_data.py -i ../data/raw -o ../data/processed/clean_characters.csv -v
-    """
-    import os
-    import glob
-    import argparse
-    import pandas as pd
-
     # Setup script argument parsing
-    ap = argparse.ArgumentParser()
-
-    ap.add_argument("-i", "--input", required=True, 
-        help="input raw csv directory path")
-    ap.add_argument("-o", "--output", required=True, 
-        help="output csv filename and path")
-    ap.add_argument("-v", "--verbose", required=False, action='store_true',
-        help="Print script output (Optional)")
-    args = vars(ap.parse_args())
-
-    input_dir = args["input"]
-    output_filename = args["output"]
-    verbose = args["verbose"]
+    print(args)
+    input_dir = args["--input"]
+    output_filename = args["--output"]
+    verbose = args["-v"]
 
     assert os.path.exists(input_dir), "Invalid input directory path provided"
     if not os.path.exists(os.path.dirname(output_filename)):


### PR DESCRIPTION
I talked to Hossam/Tiff last night when I noticed that the milestone requirements said we had to use docopt instead of what I had originally used (argparse) for script arguments. This is the updated script, it should work with the same usage arguments as listed in the README.